### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere, Replicate Models - using litellm 

### DIFF
--- a/ai/open_ai.py
+++ b/ai/open_ai.py
@@ -15,6 +15,7 @@ from ai.tokens import count_tokens
 from core.config import load_max_tokens, load_selected_model
 from data.query import MatchResult, match_file_sections
 from repository.projects import get_project_by_name
+from litellm import completion
 
 console = Console()
 
@@ -62,7 +63,7 @@ def query_llm(project_name: str, query: str):
         buffer = StringIO()
         with Halo(text='Loading response', spinner='dots'):
             try:
-                response = openai.ChatCompletion.create(
+                response = completion(
                     model=load_selected_model(),
                     messages=[message.dict() for message in messages],
                     stream=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ typer = {extras = ["all"], version = "^0.9.0"}
 rich = "^13.4.2"
 tiktoken = "^0.4.0"
 openai = "^0.27.8"
+litellm = "^0.1.356"
 termcolor = "^2.3.0"
 requests = "^2.31.0"
 toml = "^0.10.2"


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm

TLDR: gpt-code-assistant gets:
- more LLM models out of the box
- instant integration of models by modifying the `model` param (Easy to add models in the future)
- log I/O to Posthog, Sentry, Helicone, Supabase without making any code changes & get API Key management 

Here's a sample of how litellm completion is used:

```python
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```